### PR TITLE
REALITY protocol: Add ChaCha20 mode

### DIFF
--- a/tls.go
+++ b/tls.go
@@ -36,6 +36,7 @@ import (
 	"time"
 
 	"github.com/pires/go-proxyproto"
+	"golang.org/x/crypto/chacha20poly1305"
 	"golang.org/x/crypto/curve25519"
 	"golang.org/x/crypto/hkdf"
 )
@@ -189,11 +190,17 @@ func Server(ctx context.Context, conn net.Conn, config *Config) (*Conn, error) {
 				if _, err = hkdf.New(sha256.New, hs.c.AuthKey, hs.clientHello.random[:20], []byte("REALITY")).Read(hs.c.AuthKey); err != nil {
 					break
 				}
-				if config.Show {
-					fmt.Printf("REALITY remoteAddr: %v\ths.c.AuthKey[:16]: %v\n", remoteAddr, hs.c.AuthKey[:16])
+				var aead cipher.AEAD
+				if aesgcmPreferred(hs.clientHello.cipherSuites) {
+					block, _ := aes.NewCipher(hs.c.AuthKey)
+					aead, _ = cipher.NewGCM(block)
+				} else {
+					aead, _ = chacha20poly1305.New(hs.c.AuthKey)
 				}
-				block, _ := aes.NewCipher(hs.c.AuthKey)
-				aead, _ := cipher.NewGCM(block)
+				if config.Show {
+					fmt.Printf("REALITY remoteAddr: %v\ths.c.AuthKey[:16]: %v\tAEAD: %T\n", remoteAddr, hs.c.AuthKey[:16], aead)
+				}
+
 				ciphertext := make([]byte, 32)
 				plainText := make([]byte, 32)
 				copy(ciphertext, hs.clientHello.sessionId)

--- a/tls.go
+++ b/tls.go
@@ -200,7 +200,6 @@ func Server(ctx context.Context, conn net.Conn, config *Config) (*Conn, error) {
 				if config.Show {
 					fmt.Printf("REALITY remoteAddr: %v\ths.c.AuthKey[:16]: %v\tAEAD: %T\n", remoteAddr, hs.c.AuthKey[:16], aead)
 				}
-
 				ciphertext := make([]byte, 32)
 				plainText := make([]byte, 32)
 				copy(ciphertext, hs.clientHello.sessionId)


### PR DESCRIPTION
This PR introduces a new mode of REALITY protocol, authentication part. And this is the server-side update of the new mode.

Details: Client will use CHACHA20-POLY1305 as AEAD cipher for session ID encryption when a non-AES-GCM cipher is listed at the first in the Client Hello cipher suites. This would fix constant-time and efficiency problem for Go AES implementation on unsupported platforms.

The existed `aesgcmPreferred` function is used. Client implementation may need use linkname to export this internal function. This needs further discussion.

Note that this may not break the old version protocol compatibility, because all preset parrots in uTLS are AES-GCM preferred (at present). See also https://github.com/refraction-networking/utls/issues/190.