### PR TITLE
refactor: add fast exit from DetectPostHandshakeRecordsLens if finger…

### DIFF
--- a/record_detect.go
+++ b/record_detect.go
@@ -28,7 +28,11 @@ func InitAllRecords(config *Config) {
 
 func DetectPostHandshakeRecordsLens(config *Config, fingerprint string) map[string][]int {
 	if GlobalPostHandshakeRecordsLens != nil && GlobalPostHandshakeRecordsLens[fingerprint] != nil {
-		return GlobalPostHandshakeRecordsLens[fingerprint]
+		for sni := range config.ServerNames {
+			if GlobalPostHandshakeRecordsLens[fingerprint][sni] != nil {
+				return GlobalPostHandshakeRecordsLens[fingerprint]
+			}
+		}
 	}
 
 	GlobalPostHandshakeRecordsLock.Lock()

--- a/record_detect.go
+++ b/record_detect.go
@@ -17,6 +17,8 @@ var GlobalPostHandshakeRecordsLock sync.Mutex
 
 var GlobalPostHandshakeRecordsLens map[string]map[string][]int
 
+const networkType = "tcp"
+
 func InitAllRecords(config *Config) {
 	DetectPostHandshakeRecordsLens(config, "hellochrome_131") // init most used first
 	for f, _ := range ModernFingerprints {
@@ -25,6 +27,10 @@ func InitAllRecords(config *Config) {
 }
 
 func DetectPostHandshakeRecordsLens(config *Config, fingerprint string) map[string][]int {
+	if GlobalPostHandshakeRecordsLens != nil && GlobalPostHandshakeRecordsLens[fingerprint] != nil {
+		return GlobalPostHandshakeRecordsLens[fingerprint]
+	}
+
 	GlobalPostHandshakeRecordsLock.Lock()
 	if GlobalPostHandshakeRecordsLens == nil {
 		GlobalPostHandshakeRecordsLens = make(map[string]map[string][]int)
@@ -34,13 +40,13 @@ func DetectPostHandshakeRecordsLens(config *Config, fingerprint string) map[stri
 	}
 	var pending []string
 	for sni := range config.ServerNames {
-		if (GlobalPostHandshakeRecordsLens[fingerprint][sni] == nil) {
+		if GlobalPostHandshakeRecordsLens[fingerprint][sni] == nil {
 			pending = append(pending, sni)
 		}
 	}
 	GlobalPostHandshakeRecordsLock.Unlock()
 	for _, sni := range pending {
-		target, err := net.Dial("tcp", config.Dest)
+		target, err := net.Dial(networkType, config.Dest)
 		if err != nil {
 			continue
 		}
@@ -130,8 +136,8 @@ var ModernFingerprints = map[string]*utls.ClientHelloID{
 	"hello360_11_0":           &utls.Hello360_11_0,
 	"helloqq_11_1":            &utls.HelloQQ_11_1,
 
-	"hellogolang":            &utls.HelloGolang,
-	"hellorandomized":        &utls.HelloRandomized,
-	"hellorandomizedalpn":    &utls.HelloRandomizedALPN,
-	"hellorandomizednoalpn":  &utls.HelloRandomizedNoALPN,
+	"hellogolang":           &utls.HelloGolang,
+	"hellorandomized":       &utls.HelloRandomized,
+	"hellorandomizedalpn":   &utls.HelloRandomizedALPN,
+	"hellorandomizednoalpn": &utls.HelloRandomizedNoALPN,
 }


### PR DESCRIPTION
Hi! 

Maybe we can exit method faster?

```
func DetectPostHandshakeRecordsLens(config *Config, fingerprint string) map[string][]int {
        if GlobalPostHandshakeRecordsLens[fingerprint] != nil {
		return GlobalPostHandshakeRecordsLens[fingerprint]	}  //<--- ?
	GlobalPostHandshakeRecordsLock.Lock()
	if GlobalPostHandshakeRecordsLens == nil {
		GlobalPostHandshakeRecordsLens = make(map[string]map[string][]int)
	}
	if GlobalPostHandshakeRecordsLens[fingerprint] == nil {
		GlobalPostHandshakeRecordsLens[fingerprint] = make(map[string][]int)
	}
	var pending []string
	for sni := range config.ServerNames {
		if (GlobalPostHandshakeRecordsLens[fingerprint][sni] == nil) {
			pending = append(pending, sni)
		}
	}
	GlobalPostHandshakeRecordsLock.Unlock()
	for _, sni := range pending {
		target, err := net.Dial("tcp", config.Dest)
		if err != nil {
			continue
		}
		if config.Xver == 1 || config.Xver == 2 {
			if _, err = proxyproto.HeaderProxyFromAddrs(config.Xver, target.LocalAddr(), target.RemoteAddr()).WriteTo(target); err != nil {
				continue
			}
		}
		detectConn := &DetectConn{
			Conn:                     target,
			PostHandshakeRecordsLens: GlobalPostHandshakeRecordsLens[fingerprint],
			Sni:                      sni,
			Fingerprint:              fingerprint,
		}
		uConn := utls.UClient(detectConn, &utls.Config{
			ServerName: sni,
		}, *ModernFingerprints[fingerprint])
		if err = uConn.Handshake(); err != nil {
			continue
		}
		io.Copy(io.Discard, uConn)
	}
	return GlobalPostHandshakeRecordsLens[fingerprint]
}
```