### PR TITLE
prevent replaying clienthello by adding cache

### DIFF
--- a/replay_cache.go
+++ b/replay_cache.go
@@ -1,0 +1,61 @@
+package reality
+
+import (
+	"crypto/sha256"
+	"sync"
+	"time"
+)
+
+const (
+	realityReplayCacheDefaultTTL = 2 * time.Minute
+	realityReplayCacheMaxEntries = 262144
+)
+
+var realityReplayCache = struct {
+	sync.Mutex
+	entries map[[32]byte]time.Time
+}{
+	entries: make(map[[32]byte]time.Time),
+}
+
+func realityReplayCacheTTL(maxTimeDiff time.Duration) time.Duration {
+	if maxTimeDiff <= 0 {
+		return realityReplayCacheDefaultTTL
+	}
+	return maxTimeDiff + 30*time.Second
+}
+
+func realityReplayCacheKey(authKey []byte, clientHello *clientHelloMsg) [32]byte {
+	h := sha256.New()
+	h.Write(authKey)
+	h.Write(clientHello.original)
+	return [32]byte(h.Sum(nil))
+}
+
+func realityClientHelloSeenOrStore(key [32]byte, ttl time.Duration, now time.Time) bool {
+	expiresAt := now.Add(ttl)
+
+	realityReplayCache.Lock()
+	defer realityReplayCache.Unlock()
+
+	if seenUntil, ok := realityReplayCache.entries[key]; ok {
+		if seenUntil.After(now) {
+			return true
+		}
+		delete(realityReplayCache.entries, key)
+	}
+
+	if len(realityReplayCache.entries) >= realityReplayCacheMaxEntries {
+		for cachedKey, cachedUntil := range realityReplayCache.entries {
+			if !cachedUntil.After(now) {
+				delete(realityReplayCache.entries, cachedKey)
+			}
+		}
+		if len(realityReplayCache.entries) >= realityReplayCacheMaxEntries {
+			return true
+		}
+	}
+
+	realityReplayCache.entries[key] = expiresAt
+	return false
+}

--- a/tls.go
+++ b/tls.go
@@ -200,6 +200,7 @@ func Server(ctx context.Context, conn net.Conn, config *Config) (*Conn, error) {
 	}
 
 	copying := false
+	replayedClientHello := false
 
 	waitGroup := new(sync.WaitGroup)
 	waitGroup.Add(2)
@@ -258,6 +259,14 @@ func Server(ctx context.Context, conn net.Conn, config *Config) (*Conn, error) {
 					(config.MaxClientVer == nil || Value(hs.c.ClientVer[:]...) <= Value(config.MaxClientVer...)) &&
 					(config.MaxTimeDiff == 0 || time.Since(hs.c.ClientTime).Abs() <= config.MaxTimeDiff) &&
 					(config.ShortIds[hs.c.ClientShortId]) {
+					replayKey := realityReplayCacheKey(hs.c.AuthKey, hs.clientHello)
+					if realityClientHelloSeenOrStore(replayKey, realityReplayCacheTTL(config.MaxTimeDiff), time.Now()) {
+						replayedClientHello = true
+						if config.Show {
+							fmt.Printf("REALITY remoteAddr: %v\ths.c.ClientHelloReplay: true\n", remoteAddr)
+						}
+						break
+					}
 					hs.c.conn = conn
 				}
 				break
@@ -465,6 +474,8 @@ func Server(ctx context.Context, conn net.Conn, config *Config) (*Conn, error) {
 		failureReason = fmt.Sprintf("unsupported TLS version: %x", hs.c.vers)
 	} else if !config.ServerNames[hs.clientHello.serverName] {
 		failureReason = fmt.Sprintf("server name mismatch: %s", hs.clientHello.serverName)
+	} else if replayedClientHello {
+		failureReason = "replayed client hello"
 	} else if hs.c.conn != conn {
 		failureReason = "authentication failed or validation criteria not met"
 	} else if hs.c.out.handshakeLen[0] == 0 {


### PR DESCRIPTION
The purported PoC attack against REALITY at https://github.com/Anonymous376c1d0cf28/VLESS-cracker described a mechanism in which replaying ClientHello might serve as an attack vector by comparing the response reality tls endpoint against a "supposedly well behaved" legitimate TLS 1.3 state machine. 

Even though such attack cannot be reproduced against the most recent release of Xray on my instance, as well as a large number of reported false positives against CDNs/WAF-enabled endpoints, patching the replay of ClientHello might be marginally better than the current state, while adding a bit of memory burden on servers to keep the clienthello cache.

By submitting this PR I have confirmed

1. the modified version builds without error producing a functional Xray-core artifact;
2. the modified version cannot be detected by the PoC cited;
3. the modified version correctly reports clienthello replay attempts in log for further triage.