### PR TITLE
Increase REALITY target TLS record buffer to 17 KiB

### DIFF
--- a/tls.go
+++ b/tls.go
@@ -137,7 +137,7 @@ func NewRatelimitedConn(conn net.Conn, limit *LimitFallback) net.Conn {
 }
 
 var (
-	size  = 16384
+	size  = 17 * 1024
 	empty = make([]byte, size)
 	types = [7]string{
 		"Server Hello",

--- a/tls.go
+++ b/tls.go
@@ -137,7 +137,7 @@ func NewRatelimitedConn(conn net.Conn, limit *LimitFallback) net.Conn {
 }
 
 var (
-	size  = 8192
+	size  = 16384
 	empty = make([]byte, size)
 	types = [7]string{
 		"Server Hello",


### PR DESCRIPTION
Fixes XTLS/Xray-core#6356.

## Summary

Increase REALITY's target TLS record buffer from 8192 bytes to 16384 bytes.

This fixes a reproducible REALITY failure when the legitimate target server returns a TLS Certificate record slightly larger than 8192 bytes. In the linked Xray-core issue, `www.microsoft.com` can return a Certificate record with total record length 8273 bytes when OCSP/status is included:

```text
RecordHeader: 17 03 03 20 4c
Certificate handshake length: 0x203b
0x204c + 5 = 8273
```

The current REALITY code rejects it because:

```go
size = 8192
...
if handshakeLen > size { // too long
    break f
}
```

The resulting user-facing/server log error is only:

```text
REALITY: processed invalid connection ... handshake did not complete successfully
```

## Validation

I reproduced the failure with Xray-core `v26.3.27` using:

- VLESS + TCP + REALITY + Vision
- REALITY `dest`: `www.microsoft.com:443`
- `serverNames`: `www.microsoft.com`
- client fingerprint: `chrome`

Unpatched Xray failed locally with:

```text
curl: (35) Recv failure: Connection reset by peer
Certificate: 8273
hs.c.isHandshakeComplete.Load(): false
handshake did not complete successfully
```

After this patch, the same localhost REALITY server/client setup succeeds:

```text
https://www.google.com/generate_204 -> HTTP 204
```

A production deployment using the patched binary was also verified by the reporter.

## Notes

TLS records can be up to around 16 KiB, so 8192 is too tight for real-world OCSP-stapled Certificate records from some large sites/CDN edges. This patch keeps the change minimal and avoids changing protocol behavior beyond allowing larger legitimate target handshake records.
