### PR TITLE
Use TLS record limit for REALITY target buffer

### DIFF
--- a/tls.go
+++ b/tls.go
@@ -137,7 +137,7 @@ func NewRatelimitedConn(conn net.Conn, limit *LimitFallback) net.Conn {
 }
 
 var (
-	size  = 8192
+	size  = recordHeaderLen + maxCiphertextTLS13
 	empty = make([]byte, size)
 	types = [7]string{
 		"Server Hello",


### PR DESCRIPTION
Related to XTLS/Xray-core#6356.

## Summary

REALITY currently uses a hardcoded 8192-byte buffer size for target TLS records.

This patch replaces the hardcoded value with the existing TLS record bound:

```go
recordHeaderLen + maxCiphertextTLS13

This keeps the existing size variable and all downstream logic unchanged,
while deriving the bound from existing TLS constants instead of using an
arbitrary value.

Rationale

The linked Xray-core issue shows that www.microsoft.com can return a TLS
Certificate record with total length 8273 bytes, which exceeds the previous
8192-byte limit.

maxCiphertextTLS13 is already defined as 16384 + 256, and recordHeaderLen
accounts for the TLS record header. Using these existing constants keeps the
buffer bounded and aligned with the TLS 1.3 record boundary.

Relation to #33

This is an alternative implementation to #33. Instead of using 17 * 1024,
this patch reuses the existing TLS constants and keeps the change to a single
line.

Validation
Ran gofmt -w tls.go
Ran git diff --check
Verified in Docker